### PR TITLE
fix indentation error in app.run

### DIFF
--- a/flaskr.py
+++ b/flaskr.py
@@ -17,5 +17,5 @@ app.config.from_object(__name__)
 def connect_db():
 	return sqlite3.connect(app.config['DATABASE'])
 
-	if __name__ == '__main__':
-		app.run()
+if __name__ == '__main__':
+	app.run()


### PR DESCRIPTION
You really should be careful with this.

You're calling app.run() _inside_ connect_db()
